### PR TITLE
Setup Github Action to run Jest test on PR open

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - opened
       - synchronize
       - reopened
-    draft: false
+      - ready_for_review
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Run Jest Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,12 @@ name: Run Jest Tests
 on:
   pull_request:
     branches:
-      - main
+      - master
+    types:
+      - opened
+      - synchronize
+      - reopened
+    draft: false
 
 jobs:
   test:


### PR DESCRIPTION
Add a Github Action workflow to run Jest tests on PR open.

* Create `.github/workflows/test.yml` to define the Github Action workflow.
* Use `actions/checkout@v2` to checkout the repository.
* Use `actions/setup-node@v2` to set up Node.js version 20.
* Run `npm install` to install dependencies.
* Run `npm test` to run Jest tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/trinhdvt/link-ease/pull/4?shareId=022349a7-de0d-4147-895a-749927b2e24d).