### PR TITLE
Add URL reveal feature

### DIFF
--- a/src/__test__/features/reveal-url/components/url-result.test.tsx
+++ b/src/__test__/features/reveal-url/components/url-result.test.tsx
@@ -1,0 +1,88 @@
+import UrlResult from "@/features/reveal-url/components/url-result";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { jest } from "@jest/globals";
+
+describe("UrlResult", () => {
+  const mockProps = {
+    originalUrl:
+      "https://www.example.com/very/long/url/that/needs/to/be/truncated/for/display/purposes",
+    shortCode: "abc123",
+  };
+
+  beforeEach(() => {
+    // Mock clipboard API
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn(),
+      },
+    });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("renders with provided props", () => {
+    render(<UrlResult {...mockProps} />);
+
+    expect(screen.getByText(/Original URL Found/i)).toBeInTheDocument();
+    expect(screen.getByText(mockProps.shortCode)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /www\.example\.com.*\.\.\.$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("truncates long URLs correctly", () => {
+    render(<UrlResult {...mockProps} />);
+
+    const link = screen.getByRole("link", {
+      name: /www\.example\.com.*\.\.\.$/i,
+    });
+    expect(link.textContent?.length).toBeLessThan(mockProps.originalUrl.length);
+    expect(link.textContent?.endsWith("...")).toBe(true);
+  });
+
+  it("shows short URLs without truncation", () => {
+    const shortUrlProps = {
+      originalUrl: "https://example.com",
+      shortCode: "abc123",
+    };
+
+    render(<UrlResult {...shortUrlProps} />);
+
+    const link = screen.getByRole("link", { name: /example\.com/i });
+    expect(link.textContent).toBe(shortUrlProps.originalUrl);
+  });
+
+  it("copies URL to clipboard and shows confirmation", async () => {
+    render(<UrlResult {...mockProps} />);
+
+    const copyButton = screen.getByRole("button", { name: /copy url/i });
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      mockProps.originalUrl,
+    );
+    expect(screen.getByText(/copied/i)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(screen.queryByText(/copied/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/copy url/i)).toBeInTheDocument();
+  });
+
+  it("renders external links with correct attributes", () => {
+    render(<UrlResult {...mockProps} />);
+
+    const links = screen.getAllByRole("link");
+    for (const link of links) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+});

--- a/src/__test__/features/reveal-url/components/url-reveal-form.test.tsx
+++ b/src/__test__/features/reveal-url/components/url-reveal-form.test.tsx
@@ -1,0 +1,94 @@
+import { revealUrl } from "@/features/reveal-url/actions";
+import UrlRevealForm from "@/features/reveal-url/components/url-reveal-form";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+jest.mock("@/features/reveal-url/components/url-result", () => {
+  return function UrlResult() {
+    return <div>UrlResult</div>;
+  };
+});
+
+jest.mock("@/features/reveal-url/actions", () => {
+  return {
+    revealUrl: jest.fn(),
+  };
+});
+
+const mockRevealUrl = (revealUrl as jest.Mock).mockResolvedValue({
+  originalUrl: "https://linkease.com",
+  shortCode: "abc123",
+});
+
+describe(UrlRevealForm, () => {
+  it("should render the url reveal form with default state", () => {
+    render(<UrlRevealForm />);
+    expect(screen.getByText("Shortened URL or Code")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        "e.g., https://linkease.com/abc123 or abc123",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reveal Original URL" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reveal Original URL" }),
+    ).toBeDisabled();
+  });
+
+  it("should show an error message when the input URL is not found", async () => {
+    render(<UrlRevealForm />);
+
+    mockRevealUrl.mockResolvedValue({
+      error: "This shortened URL was not found in our system.",
+      shortCode: "code-not-found",
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "code-not-found" },
+    });
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reveal Original URL" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockRevealUrl).toHaveBeenCalledWith("code-not-found");
+      expect(
+        screen.getByText("This shortened URL was not found in our system."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("UrlResult")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should show the original URL when the input URL is found", async () => {
+    render(<UrlRevealForm />);
+
+    mockRevealUrl.mockResolvedValue({
+      originalUrl: "https://linkease.com",
+      shortCode: "abc123",
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "abc123" },
+    });
+
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reveal Original URL" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockRevealUrl).toHaveBeenCalledWith("abc123");
+      expect(screen.getByText("UrlResult")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__test__/reveal/page.test.tsx
+++ b/src/__test__/reveal/page.test.tsx
@@ -1,9 +1,25 @@
 import RevealPage from "@/app/reveal/page";
 import { render, screen } from "@testing-library/react";
 
-describe("Reveal Page", () => {
-  it("should render", () => {
+jest.mock("@/features/reveal-url/components/url-reveal-form", () => {
+  return function UrlRevealForm() {
+    return <div>UrlRevealForm</div>;
+  };
+});
+
+describe(RevealPage, () => {
+  it("should render the reveal page", () => {
     render(<RevealPage />);
-    expect(screen.getByText("Reveal Shortened URL")).toBeInTheDocument();
+    expect(screen.getByText("Reveal URL")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Enter a shortened URL to reveal its original destination",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("should render the url reveal form", () => {
+    render(<RevealPage />);
+    expect(screen.getByText("UrlRevealForm")).toBeInTheDocument();
   });
 });

--- a/src/app/[shortCode]/route.ts
+++ b/src/app/[shortCode]/route.ts
@@ -1,4 +1,7 @@
 import { dbAdmin } from "@/lib/firebaseAdmin";
+import type { DocumentData } from "firebase-admin/firestore";
+import type { DocumentSnapshot } from "firebase-admin/firestore";
+import { notFound } from "next/navigation";
 import { NextResponse } from "next/server";
 
 interface Params {
@@ -10,21 +13,21 @@ interface Params {
 export async function GET(_: Request, { params }: Params) {
   const { shortCode } = await params;
 
+  let docSnap: DocumentSnapshot<DocumentData>;
   try {
     const docRef = dbAdmin.collection("urls").doc(shortCode);
-    const docSnap = await docRef.get();
-
-    if (docSnap.exists) {
-      const data = docSnap.data();
-      return NextResponse.redirect(data?.original);
-    } else {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
-    }
+    docSnap = await docRef.get();
   } catch (error) {
     console.error("Error fetching document:", error);
-    return NextResponse.json(
-      { error: "Internal Server Error" },
-      { status: 500 }
-    );
+    return NextResponse.redirect("/500");
   }
+
+  if (docSnap.exists) {
+    const data = docSnap.data();
+    if (data?.expiresAt && data.expiresAt > Date.now()) {
+      return NextResponse.redirect(data?.original);
+    }
+  }
+
+  return notFound();
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,7 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans)
 }
 
 @layer base {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,7 +57,7 @@ export default function Home() {
   };
 
   return (
-    <div className="flex flex-col items-center h-full justify-center p-4">
+    <div className="flex flex-col items-center h-full justify-center">
       <h1 className="text-2xl font-semibold mb-6">
         LinkEase - Shorten Your URLs
       </h1>

--- a/src/app/reveal/page.tsx
+++ b/src/app/reveal/page.tsx
@@ -1,23 +1,41 @@
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import type { Metadata } from "next";
+import UrlRevealForm from "@/features/reveal-url/components/url-reveal-form";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Link Ease - Reveal URL",
+  description: "Reveal the original destination of shortened URLs",
+};
 
 export default function RevealPage() {
   return (
-    <div className="container mx-auto max-w-2xl">
-      <Card>
-        <CardHeader>
-          <CardTitle>Reveal Shortened URL</CardTitle>
-          <CardDescription>
+    <div className="flex flex-col items-center h-full justify-center">
+      <div className="max-w-md mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-extrabold text-gray-900 sm:text-4xl">
+            Reveal URL
+          </h1>
+          <p className="mt-3 text-lg text-gray-500">
             Enter a shortened URL to reveal its original destination
-          </CardDescription>
-        </CardHeader>
-        <CardContent>{/* Form will be added here */}</CardContent>
-      </Card>
+          </p>
+        </div>
+
+        <div className="bg-white py-8 px-6 shadow rounded-lg sm:px-10">
+          <UrlRevealForm />
+        </div>
+
+        <div className="mt-8 text-center text-sm text-gray-500">
+          <p>
+            Want to create your own shortened URLs?{" "}
+            <Link
+              href="/"
+              className="font-medium text-blue-600 hover:text-blue-500"
+            >
+              Get started here
+            </Link>
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/features/reveal-url/actions/index.ts
+++ b/src/features/reveal-url/actions/index.ts
@@ -1,0 +1,1 @@
+export * from "./reveal-url";

--- a/src/features/reveal-url/actions/reveal-url.ts
+++ b/src/features/reveal-url/actions/reveal-url.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { dbAdmin } from "@/lib/firebaseAdmin";
+
+export async function revealUrl(shortCode: string) {
+  const docRef = dbAdmin.collection("urls").doc(shortCode);
+  const docSnap = await docRef.get();
+
+  if (docSnap.exists) {
+    const data = docSnap.data();
+    const now = Date.now();
+    if (data?.expiresAt && data.expiresAt > now) {
+      return {
+        originalUrl: data?.original,
+        shortCode,
+      };
+    }
+  }
+
+  return {
+    error: "This shortened URL was not found in our system.",
+    shortCode,
+  };
+}

--- a/src/features/reveal-url/components/url-result.tsx
+++ b/src/features/reveal-url/components/url-result.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ExternalLink, Check, Copy } from "lucide-react";
+import Link from "next/link";
+
+interface UrlResultProps {
+  originalUrl: string;
+  shortCode: string;
+}
+
+export default function UrlResult({ originalUrl, shortCode }: UrlResultProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(originalUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  // Function to truncate long URLs for display
+  const truncateUrl = (url: string, maxLength = 50) => {
+    return url.length > maxLength ? `${url.substring(0, maxLength)}...` : url;
+  };
+
+  return (
+    <Card className="mt-6">
+      <CardHeader className="pb-3">
+        <CardTitle>Original URL Found</CardTitle>
+        <CardDescription>
+          The shortened code <span className="font-medium">{shortCode}</span>{" "}
+          redirects to:
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="bg-gray-50 p-3 rounded-md break-all mb-4">
+          <a
+            href={originalUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-800 hover:underline"
+          >
+            {truncateUrl(originalUrl)}
+          </a>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={copyToClipboard}
+          >
+            {copied ? (
+              <>
+                <Check className="mr-2 h-4 w-4" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="mr-2 h-4 w-4" />
+                Copy URL
+              </>
+            )}
+          </Button>
+
+          <Link href={originalUrl} target="_blank" rel="noopener noreferrer">
+            <Button className="flex-1">
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Visit Website
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/reveal-url/components/url-reveal-form.tsx
+++ b/src/features/reveal-url/components/url-reveal-form.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type React from "react";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Loader2 } from "lucide-react";
+import { revealUrl } from "@/features/reveal-url/actions";
+import UrlResult from "./url-result";
+
+export default function UrlRevealForm() {
+  const [inputUrl, setInputUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [originalUrl, setOriginalUrl] = useState<string | null>(null);
+  const [shortCode, setShortCode] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    startTransition(async () => {
+      setError(null);
+      setOriginalUrl(null);
+
+      try {
+        // Basic validation
+        if (!inputUrl.trim()) {
+          throw new Error("Please enter a URL");
+        }
+
+        // Extract short code if full URL is provided
+        let code = inputUrl.trim();
+        if (code.endsWith("/")) {
+          code = code.slice(0, -1);
+        }
+        if (code.includes("/")) {
+          const urlParts = code.split("/");
+          code = urlParts[urlParts.length - 1];
+        }
+
+        setShortCode(code);
+
+        const result = await revealUrl(code);
+
+        if (result.error) {
+          throw new Error(result.error);
+        }
+
+        setOriginalUrl(result.originalUrl);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to reveal URL");
+      }
+    });
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="url"
+            className="block text-sm font-medium text-gray-700"
+          >
+            Shortened URL or Code
+          </label>
+          <div className="mt-2">
+            <Input
+              id="url"
+              name="url"
+              type="text"
+              placeholder="e.g., https://linkease.com/abc123 or abc123"
+              value={inputUrl}
+              onChange={(e) => setInputUrl(e.target.value)}
+              className="w-full"
+              disabled={isPending}
+              autoComplete="off"
+            />
+          </div>
+        </div>
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={isPending || !inputUrl.trim()}
+        >
+          {isPending ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Revealing URL...
+            </>
+          ) : (
+            "Reveal Original URL"
+          )}
+        </Button>
+      </form>
+
+      {error && (
+        <Alert variant="destructive" className="mt-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {originalUrl && shortCode && (
+        <UrlResult originalUrl={originalUrl} shortCode={shortCode} />
+      )}
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,94 +1,94 @@
 import type { Config } from "tailwindcss";
 
 export default {
-    darkMode: ["class"],
-    content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+  darkMode: ["class"],
+  content: [
+    "./src/features/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			},
-  			sidebar: {
-  				DEFAULT: 'hsl(var(--sidebar-background))',
-  				foreground: 'hsl(var(--sidebar-foreground))',
-  				primary: 'hsl(var(--sidebar-primary))',
-  				'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
-  				accent: 'hsl(var(--sidebar-accent))',
-  				'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
-  				border: 'hsl(var(--sidebar-border))',
-  				ring: 'hsl(var(--sidebar-ring))'
-  			}
-  		},
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		keyframes: {
-  			'accordion-down': {
-  				from: {
-  					height: '0'
-  				},
-  				to: {
-  					height: 'var(--radix-accordion-content-height)'
-  				}
-  			},
-  			'accordion-up': {
-  				from: {
-  					height: 'var(--radix-accordion-content-height)'
-  				},
-  				to: {
-  					height: '0'
-  				}
-  			}
-  		},
-  		animation: {
-  			'accordion-down': 'accordion-down 0.2s ease-out',
-  			'accordion-up': 'accordion-up 0.2s ease-out'
-  		}
-  	}
+    extend: {
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          "1": "hsl(var(--chart-1))",
+          "2": "hsl(var(--chart-2))",
+          "3": "hsl(var(--chart-3))",
+          "4": "hsl(var(--chart-4))",
+          "5": "hsl(var(--chart-5))",
+        },
+        sidebar: {
+          DEFAULT: "hsl(var(--sidebar-background))",
+          foreground: "hsl(var(--sidebar-foreground))",
+          primary: "hsl(var(--sidebar-primary))",
+          "primary-foreground": "hsl(var(--sidebar-primary-foreground))",
+          accent: "hsl(var(--sidebar-accent))",
+          "accent-foreground": "hsl(var(--sidebar-accent-foreground))",
+          border: "hsl(var(--sidebar-border))",
+          ring: "hsl(var(--sidebar-ring))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: {
+            height: "0",
+          },
+          to: {
+            height: "var(--radix-accordion-content-height)",
+          },
+        },
+        "accordion-up": {
+          from: {
+            height: "var(--radix-accordion-content-height)",
+          },
+          to: {
+            height: "0",
+          },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
- Updated Tailwind config to include new content paths for features.
- Added `UrlResult` and `UrlRevealForm` components with tests for URL revealing functionality.
- Implemented `revealUrl` action to fetch original URLs from Firestore.
- Enhanced `RevealPage` to integrate the new form and display results.
- Updated global styles and minor adjustments in existing components for consistency.