### PR TITLE
feat: add dashboard page

### DIFF
--- a/src/app/api/shorten/route.ts
+++ b/src/app/api/shorten/route.ts
@@ -1,9 +1,11 @@
 import { getCurrentUser } from "@/lib/auth";
+import { clientConfig } from "@/lib/config";
 import { dbAdmin as db } from "@/lib/firebaseAdmin";
 import { NextResponse } from "next/server";
 
 const SHORTEN_URL_EXPIRATION_TIME =
-  Number.parseInt(process.env.SHORTEN_URL_EXPIRATION_TIME || "", 10) || 60 * 1000;
+  Number.parseInt(process.env.SHORTEN_URL_EXPIRATION_TIME || "", 10) ||
+  60 * 1000;
 
 export async function POST(req: Request) {
   try {
@@ -38,7 +40,7 @@ export async function POST(req: Request) {
       };
 
       const createdDoc = await db.collection("urls").add(urlData);
-      const newShortenedUrl = `${process.env.NEXT_PUBLIC_BASE_URL}/${createdDoc.id}`;
+      const newShortenedUrl = `${clientConfig.baseUrl}/${createdDoc.id}`;
 
       return NextResponse.json(
         { shortenedUrl: newShortenedUrl },

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,0 +1,100 @@
+import { getCurrentUser } from "@/lib/auth";
+import { type UrlData, getUserUrls } from "@/lib/data";
+import { render, screen } from "@testing-library/react";
+import { notFound } from "next/navigation";
+import DashboardPage from "./page";
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  getCurrentUser: jest.fn(),
+}));
+
+jest.mock("@/lib/data", () => ({
+  getUserUrls: jest.fn(),
+}));
+
+jest.mock("@/features/url-dashboard/components/url-dashboard", () => {
+  return function MockUrlDashboard({ urls }: { urls: UrlData[] }) {
+    return <div data-testid="url-dashboard">{urls.length} URLs</div>;
+  };
+});
+
+describe("DashboardPage", () => {
+  const mockUser = {
+    id: "user123",
+    name: "Test User",
+    email: "test@example.com",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getCurrentUser as jest.Mock).mockResolvedValue(mockUser);
+  });
+
+  it("redirects to 404 if user is not authenticated", async () => {
+    (getCurrentUser as jest.Mock).mockResolvedValue(null);
+
+    render(await DashboardPage());
+
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it("fetches and displays user's URLs when authenticated", async () => {
+    const mockUrls = [
+      {
+        id: "1",
+        shortCode: "abc",
+        originalUrl: "https://example.com",
+        expiresAt: "2099-01-01",
+        createdAt: "2023-01-01",
+        clicks: 5,
+      },
+      {
+        id: "2",
+        shortCode: "def",
+        originalUrl: "https://example.org",
+        expiresAt: "2099-01-01",
+        createdAt: "2023-01-02",
+        clicks: 10,
+      },
+    ];
+
+    (getUserUrls as jest.Mock).mockResolvedValue(mockUrls);
+
+    render(await DashboardPage());
+
+    expect(getCurrentUser).toHaveBeenCalled();
+    expect(getUserUrls).toHaveBeenCalledWith(mockUser.id);
+
+    expect(screen.getByText("My URLs")).toBeInTheDocument();
+    expect(
+      screen.getByText("Manage and track all your shortened URLs in one place"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("url-dashboard")).toBeInTheDocument();
+    expect(screen.getByTestId("url-dashboard").textContent).toBe("2 URLs");
+  });
+
+  it("passes empty array to UrlDashboard when user has no URLs", async () => {
+    const mockUrls: UrlData[] = [];
+
+    (getUserUrls as jest.Mock).mockResolvedValue(mockUrls);
+
+    render(await DashboardPage());
+
+    expect(getUserUrls).toHaveBeenCalledWith(mockUser.id);
+    expect(screen.getByTestId("url-dashboard")).toBeInTheDocument();
+    expect(screen.getByTestId("url-dashboard").textContent).toBe("0 URLs");
+  });
+
+  it("handles error during data fetching", async () => {
+    (getUserUrls as jest.Mock).mockRejectedValue(new Error("Failed to fetch"));
+
+    await expect(async () => {
+      render(await DashboardPage());
+    }).rejects.toThrow("Failed to fetch");
+  });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import UrlDashboard from "@/features/url-dashboard/components/url-dashboard";
 import { getCurrentUser } from "@/lib/auth";
+import { getUserUrls } from "@/lib/data";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -13,6 +14,7 @@ export default async function DashboardPage() {
   if (!user) {
     return notFound();
   }
+  const allUrls = await getUserUrls(user.id);
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -23,7 +25,7 @@ export default async function DashboardPage() {
         </p>
       </div>
 
-      <UrlDashboard />
+      <UrlDashboard urls={allUrls} />
     </div>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,29 @@
+import UrlDashboard from "@/features/url-dashboard/components/url-dashboard";
+import { getCurrentUser } from "@/lib/auth";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+export const metadata: Metadata = {
+  title: "My URLs | Link Ease",
+  description: "Manage all your shortened URLs in one place",
+};
+
+export default async function DashboardPage() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return notFound();
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight">My URLs</h1>
+        <p className="text-muted-foreground mt-2">
+          Manage and track all your shortened URLs in one place
+        </p>
+      </div>
+
+      <UrlDashboard />
+    </div>
+  );
+}

--- a/src/features/url-dashboard/components/url-dashboard.test.tsx
+++ b/src/features/url-dashboard/components/url-dashboard.test.tsx
@@ -1,0 +1,95 @@
+import type { UrlData } from "@/lib/data";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import UrlDashboard from "./url-dashboard";
+
+// Mock UrlTable to just render a div with the urls prop
+jest.mock("./url-table", () => ({
+  __esModule: true,
+  default: ({ urls }: { urls: UrlData[] }) => (
+    <div data-testid="url-table">{urls.map((u) => u.shortCode).join(",")}</div>
+  ),
+}));
+
+describe("UrlDashboard", () => {
+  const now = Date.now();
+  const urls: UrlData[] = [
+    {
+      id: "1",
+      originalUrl: "https://a.com",
+      shortCode: "a1",
+      createdAt: new Date(now - 100000).toISOString(),
+      expiresAt: new Date(now + 100000).toISOString(),
+      clicks: 5,
+    },
+    {
+      id: "2",
+      originalUrl: "https://b.com",
+      shortCode: "b2",
+      createdAt: new Date(now - 200000).toISOString(),
+      expiresAt: new Date(now - 1000).toISOString(), // expired
+      clicks: 10,
+    },
+    {
+      id: "3",
+      originalUrl: "https://c.com",
+      shortCode: "c3",
+      createdAt: new Date(now - 300000).toISOString(),
+      expiresAt: new Date(now + 200000).toISOString(),
+      clicks: 1,
+    },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders search, tabs, sort, and UrlTable", () => {
+    render(<UrlDashboard urls={urls} />);
+    expect(screen.getByPlaceholderText(/search urls/i)).toBeInTheDocument();
+    expect(screen.getByText(/All/)).toBeInTheDocument();
+    expect(screen.getByText(/Active/)).toBeInTheDocument();
+    expect(screen.getByText(/Expired/)).toBeInTheDocument();
+    expect(screen.getByText(/Newest first/)).toBeInTheDocument();
+    expect(screen.getByTestId("url-table")).toBeInTheDocument();
+  });
+
+  it("filters by search input", () => {
+    render(<UrlDashboard urls={urls} />);
+    fireEvent.change(screen.getByPlaceholderText(/search urls/i), {
+      target: { value: "b.com" },
+    });
+    expect(screen.getByTestId("url-table").textContent).toBe("b2");
+  });
+
+  it("filters by status: active", async () => {
+    render(<UrlDashboard urls={urls} />);
+    fireEvent.mouseDown(screen.getByText(/Active/));
+
+    const urlTable = screen.getByTestId("url-table");
+
+    expect(urlTable).toHaveTextContent("a1");
+    expect(urlTable).toHaveTextContent("c3");
+    expect(urlTable).not.toHaveTextContent("b2");
+  });
+
+  it("filters by status: expired", () => {
+    render(<UrlDashboard urls={urls} />);
+    fireEvent.mouseDown(screen.getByText(/Expired/));
+    expect(screen.getByTestId("url-table").textContent).toBe("b2");
+  });
+
+  it("sorts by clicks descending", () => {
+    render(<UrlDashboard urls={urls} />);
+    fireEvent.click(screen.getByText(/Newest first/));
+    fireEvent.click(screen.getByText(/Most clicks/));
+    expect(screen.getByTestId("url-table").textContent).toBe("b2,a1,c3");
+  });
+
+  it("sorts by original URL A-Z", () => {
+    render(<UrlDashboard urls={urls} />);
+    fireEvent.click(screen.getByText(/Newest first/));
+    fireEvent.click(screen.getByText(/Original URL \(A-Z\)/));
+    expect(screen.getByTestId("url-table").textContent).toBe("a1,b2,c3");
+  });
+});

--- a/src/features/url-dashboard/components/url-dashboard.tsx
+++ b/src/features/url-dashboard/components/url-dashboard.tsx
@@ -9,20 +9,22 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getMockUrls } from "@/lib/data";
+
+import type { UrlData } from "@/lib/data";
 import { useState } from "react";
 import UrlTable from "./url-table";
 
-// Get mock data
-const allUrls = getMockUrls();
+type UrlDashboardProps = {
+  urls: UrlData[];
+};
 
-export default function UrlDashboard() {
+export default function UrlDashboard({ urls }: UrlDashboardProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("created_desc");
   const [statusFilter, setStatusFilter] = useState("all");
 
   // Filter URLs based on search query and status
-  const filteredUrls = allUrls.filter((url) => {
+  const filteredUrls = urls.filter((url) => {
     // Search filter
     const matchesSearch =
       searchQuery === "" ||

--- a/src/features/url-dashboard/components/url-dashboard.tsx
+++ b/src/features/url-dashboard/components/url-dashboard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getMockUrls } from "@/lib/data";
+import { useState } from "react";
+import UrlTable from "./url-table";
+
+// Get mock data
+const allUrls = getMockUrls();
+
+export default function UrlDashboard() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState("created_desc");
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  // Filter URLs based on search query and status
+  const filteredUrls = allUrls.filter((url) => {
+    // Search filter
+    const matchesSearch =
+      searchQuery === "" ||
+      url.originalUrl.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      url.shortCode.toLowerCase().includes(searchQuery.toLowerCase());
+
+    // Status filter
+    const now = new Date();
+    const isExpired = new Date(url.expiresAt) < now;
+
+    if (statusFilter === "all") return matchesSearch;
+    if (statusFilter === "active") return matchesSearch && !isExpired;
+    if (statusFilter === "expired") return matchesSearch && isExpired;
+
+    return matchesSearch;
+  });
+
+  // Sort URLs
+  const sortedUrls = [...filteredUrls].sort((a, b) => {
+    switch (sortBy) {
+      case "created_desc":
+        return (
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+        );
+      case "created_asc":
+        return (
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+        );
+      case "expires_desc":
+        return (
+          new Date(b.expiresAt).getTime() - new Date(a.expiresAt).getTime()
+        );
+      case "expires_asc":
+        return (
+          new Date(a.expiresAt).getTime() - new Date(b.expiresAt).getTime()
+        );
+      case "original_az":
+        return a.originalUrl.localeCompare(b.originalUrl);
+      case "original_za":
+        return b.originalUrl.localeCompare(a.originalUrl);
+      case "clicks_desc":
+        return b.clicks - a.clicks;
+      case "clicks_asc":
+        return a.clicks - b.clicks;
+      default:
+        return 0;
+    }
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col md:flex-row gap-4 justify-between">
+        <div className="w-full md:w-1/3">
+          <Input
+            placeholder="Search URLs..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full"
+          />
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-4">
+          <Tabs
+            defaultValue="all"
+            className="w-full sm:w-auto"
+            onValueChange={setStatusFilter}
+            value={statusFilter}
+          >
+            <TabsList className="grid w-full grid-cols-3">
+              <TabsTrigger value="all">All</TabsTrigger>
+              <TabsTrigger value="active">Active</TabsTrigger>
+              <TabsTrigger value="expired">Expired</TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <Select value={sortBy} onValueChange={setSortBy}>
+            <SelectTrigger className="w-full sm:w-[220px]">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="created_desc">Newest first</SelectItem>
+              <SelectItem value="created_asc">Oldest first</SelectItem>
+              <SelectItem value="expires_desc">Expires latest</SelectItem>
+              <SelectItem value="expires_asc">Expires soonest</SelectItem>
+              <SelectItem value="original_az">Original URL (A-Z)</SelectItem>
+              <SelectItem value="original_za">Original URL (Z-A)</SelectItem>
+              <SelectItem value="clicks_desc">Most clicks</SelectItem>
+              <SelectItem value="clicks_asc">Fewest clicks</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <UrlTable urls={sortedUrls} />
+    </div>
+  );
+}

--- a/src/features/url-dashboard/components/url-table.test.tsx
+++ b/src/features/url-dashboard/components/url-table.test.tsx
@@ -1,0 +1,118 @@
+import type { UrlData } from "@/lib/data";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import UrlTable from "./url-table";
+
+// Mock lucide-react icons
+jest.mock("lucide-react", () => ({
+  BarChart2: () => <svg data-testid="icon-analytics" />,
+  Check: () => <svg data-testid="icon-check" />,
+  ChevronLeft: () => <svg data-testid="icon-left" />,
+  ChevronRight: () => <svg data-testid="icon-right" />,
+  Copy: () => <svg data-testid="icon-copy" />,
+  ExternalLink: () => <svg data-testid="icon-external" />,
+  Trash2: () => <svg data-testid="icon-trash" />,
+}));
+
+// Mock clipboard
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+  },
+});
+
+const baseUrl = "https://test.com";
+
+jest.mock("@/lib/config", () => ({
+  clientConfig: { baseUrl: "https://test.com", domain: "test.com" },
+}));
+
+describe("UrlTable", () => {
+  const urls: UrlData[] = [
+    {
+      id: "1",
+      originalUrl:
+        "https://verylongurl.com/with/a/lot/of/segments/and/parameters/that/should/be/truncated/for/display",
+      shortCode: "abc123",
+      createdAt: new Date(Date.now() - 2000000).toISOString(),
+      expiresAt: new Date(Date.now() + 1000000).toISOString(),
+      clicks: 42,
+    },
+    {
+      id: "2",
+      originalUrl: "https://expired.com",
+      shortCode: "exp456",
+      createdAt: new Date(Date.now() - 3000000).toISOString(),
+      expiresAt: new Date(Date.now() - 1000000).toISOString(),
+      clicks: 0,
+    },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it("renders empty state", () => {
+    render(<UrlTable urls={[]} />);
+    expect(screen.getByText(/No URLs found/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Create New URL/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders table rows for each url", () => {
+    render(<UrlTable urls={urls} />);
+    expect(screen.getByText(/verylongurl.com/)).toBeInTheDocument();
+    expect(screen.getByText(/expired.com/)).toBeInTheDocument();
+    expect(screen.getAllByTestId("icon-external")).toHaveLength(2);
+    expect(screen.getAllByTestId("icon-copy")).toHaveLength(2);
+    expect(screen.getAllByTestId("icon-trash")).toHaveLength(2);
+  });
+
+  it("truncates long URLs", () => {
+    render(<UrlTable urls={urls} />);
+    expect(screen.getByText(/verylongurl.com.*\.\.\./i)).toBeInTheDocument();
+  });
+
+  it("copies shortened URL to clipboard and shows check icon", async () => {
+    jest.useFakeTimers();
+    render(<UrlTable urls={urls} />);
+    const copyButtons = screen.getAllByRole("button", { name: "" });
+    // Copy button is the second button in the first row
+    await act(async () => {
+      fireEvent.click(copyButtons[1]);
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `${baseUrl}/exp456`,
+    );
+    expect(screen.getByTestId("icon-check")).toBeInTheDocument();
+    // After timeout, icon disappears
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(screen.queryByTestId("icon-check")).not.toBeInTheDocument();
+  });
+
+  it("shows pagination controls if more than 10 urls", () => {
+    const manyUrls = Array.from({ length: 15 }, (_, i) => ({
+      ...urls[0],
+      id: String(i),
+      shortCode: `code${i}`,
+      originalUrl: `https://site${i}.com`,
+      createdAt: new Date(Date.now() - 4000000 - i * 1000).toISOString(),
+    }));
+    render(<UrlTable urls={manyUrls} />);
+    expect(screen.getByText(/Page 1 of 2/)).toBeInTheDocument();
+    expect(screen.getByTestId("icon-right")).toBeInTheDocument();
+    // Click next page
+    fireEvent.click(screen.getByTestId("icon-right"));
+    expect(screen.getByText(/Page 2 of 2/)).toBeInTheDocument();
+    expect(screen.getByTestId("icon-left")).toBeInTheDocument();
+  });
+
+  it("renders analytics and delete buttons", () => {
+    render(<UrlTable urls={urls} />);
+    expect(screen.getAllByTestId("icon-analytics")).toHaveLength(2);
+    expect(screen.getAllByTestId("icon-trash")).toHaveLength(2);
+  });
+});

--- a/src/features/url-dashboard/components/url-table.tsx
+++ b/src/features/url-dashboard/components/url-table.tsx
@@ -10,6 +10,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { clientConfig } from "@/lib/config";
 import type { UrlData } from "@/lib/data";
 
@@ -56,10 +62,6 @@ export default function UrlTable({ urls }: UrlTableProps) {
     }).format(date);
   };
 
-  const isExpired = (dateString: string) => {
-    return new Date(dateString) < new Date();
-  };
-
   // Function to truncate long URLs for display
   const truncateUrl = (url: string, maxLength = 50) => {
     return url.length > maxLength ? `${url.substring(0, maxLength)}...` : url;
@@ -95,79 +97,90 @@ export default function UrlTable({ urls }: UrlTableProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {paginatedUrls.map((url) => (
-                <TableRow key={url.id}>
-                  <TableCell className="font-medium">
-                    <div className="flex items-center space-x-2">
-                      <div
-                        className="truncate max-w-[300px]"
-                        title={url.originalUrl}
-                      >
-                        {truncateUrl(url.originalUrl, 40)}
+              {paginatedUrls.map((url) => {
+                const isExpired = new Date(url.expiresAt) < new Date();
+
+                return (
+                  <TableRow key={url.id}>
+                    <TableCell className="font-medium">
+                      <div className="flex items-center space-x-2">
+                        <div
+                          className="truncate max-w-[300px]"
+                          title={url.originalUrl}
+                        >
+                          {truncateUrl(url.originalUrl, 40)}
+                        </div>
+                        <Link
+                          href={url.originalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-gray-500 hover:text-gray-700"
+                        >
+                          <ExternalLink size={16} />
+                        </Link>
                       </div>
-                      <Link
-                        href={url.originalUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-gray-500 hover:text-gray-700"
-                      >
-                        <ExternalLink size={16} />
-                      </Link>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center space-x-2">
-                      <span className="font-mono text-sm">{`${clientConfig.domain}/${url.shortCode}`}</span>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          copyToClipboard(
-                            `${clientConfig.baseUrl}/${url.shortCode}`,
-                            url.id,
-                          )
-                        }
-                        className="text-gray-500 hover:text-gray-700"
-                      >
-                        {copiedId === url.id ? (
-                          <Check size={16} className="text-green-500" />
-                        ) : (
-                          <Copy size={16} />
-                        )}
-                      </button>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge
-                      variant={
-                        isExpired(url.expiresAt) ? "destructive" : "outline"
-                      }
-                    >
-                      {isExpired(url.expiresAt) ? "Expired" : "Active"}
-                    </Badge>
-                    <div className="text-xs text-muted-foreground mt-1">
-                      {formatDate(url.expiresAt)}
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {url.clicks.toLocaleString()}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex justify-end space-x-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        title="View Analytics"
-                        disabled={true}
-                      >
-                        <BarChart2 size={16} />
-                      </Button>
-                      <Button variant="ghost" size="icon" title="Delete URL">
-                        <Trash2 size={16} />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center space-x-2">
+                        <span className="font-mono text-sm">{`${clientConfig.domain}/${url.shortCode}`}</span>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            copyToClipboard(
+                              `${clientConfig.baseUrl}/${url.shortCode}`,
+                              url.id,
+                            )
+                          }
+                          className="text-gray-500 hover:text-gray-700"
+                        >
+                          {copiedId === url.id ? (
+                            <Check size={16} className="text-green-500" />
+                          ) : (
+                            <Copy size={16} />
+                          )}
+                        </button>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <TooltipProvider delayDuration={200}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Badge
+                              variant={isExpired ? "destructive" : "outline"}
+                            >
+                              {isExpired ? "Expired" : "Active"}
+                            </Badge>
+                          </TooltipTrigger>
+                          <TooltipContent hidden={!isExpired}>
+                            This URL has expired and will be deleted soon.
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {formatDate(url.expiresAt)}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {url.clicks.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex justify-end space-x-2">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          title="View Analytics"
+                          disabled={true}
+                        >
+                          <BarChart2 size={16} />
+                        </Button>
+                        <Button variant="ghost" size="icon" title="Delete URL">
+                          <Trash2 size={16} />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </div>

--- a/src/features/url-dashboard/components/url-table.tsx
+++ b/src/features/url-dashboard/components/url-table.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { UrlData } from "@/lib/data";
+
+import {
+  BarChart2,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  Trash2,
+} from "lucide-react";
+import { useState } from "react";
+
+interface UrlTableProps {
+  urls: UrlData[];
+}
+
+export default function UrlTable({ urls }: UrlTableProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+
+  // Calculate pagination
+  const totalPages = Math.ceil(urls.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedUrls = urls.slice(startIndex, startIndex + itemsPerPage);
+
+  const copyToClipboard = (text: string, id: string) => {
+    navigator.clipboard.writeText(text);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date);
+  };
+
+  const isExpired = (dateString: string) => {
+    return new Date(dateString) < new Date();
+  };
+
+  // Function to truncate long URLs for display
+  const truncateUrl = (url: string, maxLength = 50) => {
+    return url.length > maxLength ? `${url.substring(0, maxLength)}...` : url;
+  };
+
+  if (urls.length === 0) {
+    return (
+      <div className="text-center py-12 border rounded-lg bg-gray-50">
+        <h3 className="text-lg font-medium">No URLs found</h3>
+        <p className="text-muted-foreground mt-2">
+          You haven't created any shortened URLs yet, or none match your current
+          filters.
+        </p>
+        <Button className="mt-4">Create New URL</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="border rounded-lg overflow-hidden">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[40%]">Original URL</TableHead>
+                <TableHead className="w-[20%]">Shortened URL</TableHead>
+                <TableHead className="w-[15%]">Expiration</TableHead>
+                <TableHead className="w-[10%] text-right">Clicks</TableHead>
+                <TableHead className="w-[15%] text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginatedUrls.map((url) => (
+                <TableRow key={url.id}>
+                  <TableCell className="font-medium">
+                    <div className="flex items-center space-x-2">
+                      <div
+                        className="truncate max-w-[300px]"
+                        title={url.originalUrl}
+                      >
+                        {truncateUrl(url.originalUrl, 40)}
+                      </div>
+                      <a
+                        href={url.originalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-gray-500 hover:text-gray-700"
+                      >
+                        <ExternalLink size={16} />
+                      </a>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center space-x-2">
+                      <span className="font-mono text-sm">{`linkease.com/${url.shortCode}`}</span>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          copyToClipboard(
+                            `https://linkease.com/${url.shortCode}`,
+                            url.id,
+                          )
+                        }
+                        className="text-gray-500 hover:text-gray-700"
+                      >
+                        {copiedId === url.id ? (
+                          <Check size={16} className="text-green-500" />
+                        ) : (
+                          <Copy size={16} />
+                        )}
+                      </button>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={
+                        isExpired(url.expiresAt) ? "destructive" : "outline"
+                      }
+                    >
+                      {isExpired(url.expiresAt) ? "Expired" : "Active"}
+                    </Badge>
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {formatDate(url.expiresAt)}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {url.clicks.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end space-x-2">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        title="View Analytics"
+                      >
+                        <BarChart2 size={16} />
+                      </Button>
+                      <Button variant="ghost" size="icon" title="Delete URL">
+                        <Trash2 size={16} />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <div className="text-sm text-muted-foreground">
+            Showing {startIndex + 1}-
+            {Math.min(startIndex + itemsPerPage, urls.length)} of {urls.length}{" "}
+            URLs
+          </div>
+          <div className="flex items-center space-x-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+              disabled={currentPage === 1}
+            >
+              <ChevronLeft size={16} />
+            </Button>
+            <div className="text-sm">
+              Page {currentPage} of {totalPages}
+            </div>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() =>
+                setCurrentPage((prev) => Math.min(prev + 1, totalPages))
+              }
+              disabled={currentPage === totalPages}
+            >
+              <ChevronRight size={16} />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/url-dashboard/components/url-table.tsx
+++ b/src/features/url-dashboard/components/url-table.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { clientConfig } from "@/lib/config";
 import type { UrlData } from "@/lib/data";
 
 import {
@@ -21,6 +22,7 @@ import {
   ExternalLink,
   Trash2,
 } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 
 interface UrlTableProps {
@@ -71,7 +73,9 @@ export default function UrlTable({ urls }: UrlTableProps) {
           You haven't created any shortened URLs yet, or none match your current
           filters.
         </p>
-        <Button className="mt-4">Create New URL</Button>
+        <Button className="mt-4" asChild>
+          <Link href="/">Create New URL</Link>
+        </Button>
       </div>
     );
   }
@@ -101,24 +105,24 @@ export default function UrlTable({ urls }: UrlTableProps) {
                       >
                         {truncateUrl(url.originalUrl, 40)}
                       </div>
-                      <a
+                      <Link
                         href={url.originalUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-gray-500 hover:text-gray-700"
                       >
                         <ExternalLink size={16} />
-                      </a>
+                      </Link>
                     </div>
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center space-x-2">
-                      <span className="font-mono text-sm">{`linkease.com/${url.shortCode}`}</span>
+                      <span className="font-mono text-sm">{`${clientConfig.domain}/${url.shortCode}`}</span>
                       <button
                         type="button"
                         onClick={() =>
                           copyToClipboard(
-                            `https://linkease.com/${url.shortCode}`,
+                            `${clientConfig.baseUrl}/${url.shortCode}`,
                             url.id,
                           )
                         }
@@ -153,6 +157,7 @@ export default function UrlTable({ urls }: UrlTableProps) {
                         variant="ghost"
                         size="icon"
                         title="View Analytics"
+                        disabled={true}
                       >
                         <BarChart2 size={16} />
                       </Button>

--- a/src/features/user/components/user-profile.test.tsx
+++ b/src/features/user/components/user-profile.test.tsx
@@ -32,13 +32,24 @@ describe(UserProfile, () => {
   });
 
   describe("user menu actions", () => {
-    it("renders sign out button", async () => {
-      render(<UserProfile user={mockUser} />);
+    function triggerDropdown() {
       const dropdownTrigger = screen.getByTestId("user-profile-trigger");
 
       fireEvent.keyDown(dropdownTrigger, {
         key: "Enter",
       });
+    }
+
+    it("renders dashboard link", async () => {
+      render(<UserProfile user={mockUser} />);
+      triggerDropdown();
+      const dashboardLink = await screen.findByText("Dashboard");
+      expect(dashboardLink).toBeInTheDocument();
+    });
+
+    it("renders sign out button", async () => {
+      render(<UserProfile user={mockUser} />);
+      triggerDropdown();
 
       const signOutButton = await screen.findByText("Sign out");
       expect(signOutButton).toBeInTheDocument();

--- a/src/features/user/components/user-profile.test.tsx
+++ b/src/features/user/components/user-profile.test.tsx
@@ -2,12 +2,6 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { User } from "../types";
 import UserProfile from "./user-profile";
 
-jest.mock("next/navigation", () => ({
-  useRouter: jest.fn(() => ({
-    refresh: jest.fn(),
-  })),
-}));
-
 global.fetch = jest.fn();
 
 describe(UserProfile, () => {

--- a/src/features/user/components/user-profile.tsx
+++ b/src/features/user/components/user-profile.tsx
@@ -19,15 +19,13 @@ type UserProfileProps = {
 };
 
 export default function UserProfile({ user }: UserProfileProps) {
-  const router = useRouter();
-
   const handleSignOut = async () => {
     try {
       await fetch("/api/logout", {
         method: "POST",
         credentials: "include",
       });
-      router.refresh();
+      window.location.href = "/";
     } catch (error) {
       console.error("Error signing out: ", error);
     }

--- a/src/features/user/components/user-profile.tsx
+++ b/src/features/user/components/user-profile.tsx
@@ -5,14 +5,15 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import { ChevronDown, LogOut } from "lucide-react";
+import { ChevronDown, LayoutDashboard, LogOut } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import type { User } from "@/features/user/types";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 type UserProfileProps = {
   user: User;
@@ -57,6 +58,13 @@ export default function UserProfile({ user }: UserProfileProps) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent className="max-w-56">
+              <DropdownMenuItem>
+                <Link href="/dashboard" className="flex items-center gap-2">
+                  <LayoutDashboard />
+                  <span>Dashboard</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="cursor-pointer"
                 onClick={handleSignOut}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,8 @@
+import type { User } from "@/features/user/types";
+import type { DecodedIdToken } from "firebase-admin/auth";
 import { cookies } from "next/headers";
 import { serverConfig } from "./config";
 import { authAdmin } from "./firebaseAdmin";
-import type { DecodedIdToken } from "firebase-admin/auth";
-import type { User } from "@/features/user/types";
 
 /**
  * Retrieves and verifies the authentication token from the session cookie.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,3 +7,8 @@ export const serverConfig = {
   },
   authCookiePath: "/",
 };
+
+export const clientConfig = {
+  baseUrl: process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:9002",
+  domain: process.env.NEXT_PUBLIC_DOMAIN || "localhost:9002",
+};

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,0 +1,157 @@
+export interface UrlData {
+  id: string;
+  originalUrl: string;
+  shortCode: string;
+  createdAt: string;
+  expiresAt: string;
+  clicks: number;
+}
+
+export function getMockUrls(): UrlData[] {
+  // Current date for reference
+  const now = new Date();
+
+  // Helper to create dates relative to now
+  const daysFromNow = (days: number) => {
+    const date = new Date(now);
+    date.setDate(date.getDate() + days);
+    return date.toISOString();
+  };
+
+  const daysAgo = (days: number) => {
+    const date = new Date(now);
+    date.setDate(date.getDate() - days);
+    return date.toISOString();
+  };
+
+  return [
+    {
+      id: "1",
+      originalUrl:
+        "https://www.example.com/very/long/path/to/an/article/about/technology/and/its/impact/on/society",
+      shortCode: "tech1",
+      createdAt: daysAgo(15),
+      expiresAt: daysFromNow(75),
+      clicks: 1243,
+    },
+    {
+      id: "2",
+      originalUrl:
+        "https://www.productlaunch.com/new-feature-announcement-2023",
+      shortCode: "launch",
+      createdAt: daysAgo(5),
+      expiresAt: daysFromNow(25),
+      clicks: 532,
+    },
+    {
+      id: "3",
+      originalUrl: "https://www.docs.example.org/api/reference/v2/endpoints",
+      shortCode: "api-docs",
+      createdAt: daysAgo(45),
+      expiresAt: daysAgo(5),
+      clicks: 2891,
+    },
+    {
+      id: "4",
+      originalUrl:
+        "https://www.webinar-registration.com/upcoming/blockchain-basics",
+      shortCode: "webinar",
+      createdAt: daysAgo(2),
+      expiresAt: daysFromNow(12),
+      clicks: 89,
+    },
+    {
+      id: "5",
+      originalUrl:
+        "https://www.example.com/blog/top-10-productivity-tips-for-remote-workers",
+      shortCode: "remote",
+      createdAt: daysAgo(60),
+      expiresAt: daysAgo(10),
+      clicks: 1567,
+    },
+    {
+      id: "6",
+      originalUrl: "https://www.conference.example.com/schedule/day-1",
+      shortCode: "conf-d1",
+      createdAt: daysAgo(10),
+      expiresAt: daysFromNow(2),
+      clicks: 423,
+    },
+    {
+      id: "7",
+      originalUrl:
+        "https://www.example.org/resources/whitepaper-ai-trends-2023.pdf",
+      shortCode: "ai-paper",
+      createdAt: daysAgo(30),
+      expiresAt: daysFromNow(150),
+      clicks: 752,
+    },
+    {
+      id: "8",
+      originalUrl:
+        "https://www.job-board.example.com/senior-developer-position",
+      shortCode: "job-dev",
+      createdAt: daysAgo(7),
+      expiresAt: daysFromNow(23),
+      clicks: 211,
+    },
+    {
+      id: "9",
+      originalUrl: "https://www.example.edu/courses/fall-2023/computer-science",
+      shortCode: "cs-fall",
+      createdAt: daysAgo(20),
+      expiresAt: daysAgo(15),
+      clicks: 189,
+    },
+    {
+      id: "10",
+      originalUrl: "https://www.product-demo.example.com/new-features",
+      shortCode: "demo",
+      createdAt: daysAgo(1),
+      expiresAt: daysFromNow(29),
+      clicks: 47,
+    },
+    {
+      id: "11",
+      originalUrl: "https://www.example.com/pricing/enterprise",
+      shortCode: "pricing",
+      createdAt: daysAgo(120),
+      expiresAt: daysFromNow(245),
+      clicks: 3254,
+    },
+    {
+      id: "12",
+      originalUrl: "https://www.newsletter.example.com/subscribe/tech-weekly",
+      shortCode: "news",
+      createdAt: daysAgo(25),
+      expiresAt: daysFromNow(340),
+      clicks: 876,
+    },
+    {
+      id: "13",
+      originalUrl:
+        "https://www.example.org/events/annual-conference-2023/registration",
+      shortCode: "event-reg",
+      createdAt: daysAgo(18),
+      expiresAt: daysAgo(2),
+      clicks: 1432,
+    },
+    {
+      id: "14",
+      originalUrl: "https://www.example.com/support/ticket/submit",
+      shortCode: "support",
+      createdAt: daysAgo(40),
+      expiresAt: daysFromNow(325),
+      clicks: 321,
+    },
+    {
+      id: "15",
+      originalUrl:
+        "https://www.research-paper.example.edu/quantum-computing-advances",
+      shortCode: "quantum",
+      createdAt: daysAgo(90),
+      expiresAt: daysFromNow(275),
+      clicks: 567,
+    },
+  ];
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,3 +1,5 @@
+import { dbAdmin as db } from "@/lib/firebaseAdmin";
+
 export interface UrlData {
   id: string;
   originalUrl: string;
@@ -7,151 +9,53 @@ export interface UrlData {
   clicks: number;
 }
 
-export function getMockUrls(): UrlData[] {
-  // Current date for reference
-  const now = new Date();
+export async function getUserUrls(userId: string): Promise<UrlData[]> {
+  if (!userId) {
+    return [];
+  }
 
-  // Helper to create dates relative to now
-  const daysFromNow = (days: number) => {
-    const date = new Date(now);
-    date.setDate(date.getDate() + days);
-    return date.toISOString();
-  };
+  try {
+    const urlsSnapshot = await db
+      .collection("urls")
+      .where("ownerId", "==", userId)
+      .get();
 
-  const daysAgo = (days: number) => {
-    const date = new Date(now);
-    date.setDate(date.getDate() - days);
-    return date.toISOString();
-  };
+    if (urlsSnapshot.empty) {
+      return [];
+    }
 
-  return [
-    {
-      id: "1",
-      originalUrl:
-        "https://www.example.com/very/long/path/to/an/article/about/technology/and/its/impact/on/society",
-      shortCode: "tech1",
-      createdAt: daysAgo(15),
-      expiresAt: daysFromNow(75),
-      clicks: 1243,
-    },
-    {
-      id: "2",
-      originalUrl:
-        "https://www.productlaunch.com/new-feature-announcement-2023",
-      shortCode: "launch",
-      createdAt: daysAgo(5),
-      expiresAt: daysFromNow(25),
-      clicks: 532,
-    },
-    {
-      id: "3",
-      originalUrl: "https://www.docs.example.org/api/reference/v2/endpoints",
-      shortCode: "api-docs",
-      createdAt: daysAgo(45),
-      expiresAt: daysAgo(5),
-      clicks: 2891,
-    },
-    {
-      id: "4",
-      originalUrl:
-        "https://www.webinar-registration.com/upcoming/blockchain-basics",
-      shortCode: "webinar",
-      createdAt: daysAgo(2),
-      expiresAt: daysFromNow(12),
-      clicks: 89,
-    },
-    {
-      id: "5",
-      originalUrl:
-        "https://www.example.com/blog/top-10-productivity-tips-for-remote-workers",
-      shortCode: "remote",
-      createdAt: daysAgo(60),
-      expiresAt: daysAgo(10),
-      clicks: 1567,
-    },
-    {
-      id: "6",
-      originalUrl: "https://www.conference.example.com/schedule/day-1",
-      shortCode: "conf-d1",
-      createdAt: daysAgo(10),
-      expiresAt: daysFromNow(2),
-      clicks: 423,
-    },
-    {
-      id: "7",
-      originalUrl:
-        "https://www.example.org/resources/whitepaper-ai-trends-2023.pdf",
-      shortCode: "ai-paper",
-      createdAt: daysAgo(30),
-      expiresAt: daysFromNow(150),
-      clicks: 752,
-    },
-    {
-      id: "8",
-      originalUrl:
-        "https://www.job-board.example.com/senior-developer-position",
-      shortCode: "job-dev",
-      createdAt: daysAgo(7),
-      expiresAt: daysFromNow(23),
-      clicks: 211,
-    },
-    {
-      id: "9",
-      originalUrl: "https://www.example.edu/courses/fall-2023/computer-science",
-      shortCode: "cs-fall",
-      createdAt: daysAgo(20),
-      expiresAt: daysAgo(15),
-      clicks: 189,
-    },
-    {
-      id: "10",
-      originalUrl: "https://www.product-demo.example.com/new-features",
-      shortCode: "demo",
-      createdAt: daysAgo(1),
-      expiresAt: daysFromNow(29),
-      clicks: 47,
-    },
-    {
-      id: "11",
-      originalUrl: "https://www.example.com/pricing/enterprise",
-      shortCode: "pricing",
-      createdAt: daysAgo(120),
-      expiresAt: daysFromNow(245),
-      clicks: 3254,
-    },
-    {
-      id: "12",
-      originalUrl: "https://www.newsletter.example.com/subscribe/tech-weekly",
-      shortCode: "news",
-      createdAt: daysAgo(25),
-      expiresAt: daysFromNow(340),
-      clicks: 876,
-    },
-    {
-      id: "13",
-      originalUrl:
-        "https://www.example.org/events/annual-conference-2023/registration",
-      shortCode: "event-reg",
-      createdAt: daysAgo(18),
-      expiresAt: daysAgo(2),
-      clicks: 1432,
-    },
-    {
-      id: "14",
-      originalUrl: "https://www.example.com/support/ticket/submit",
-      shortCode: "support",
-      createdAt: daysAgo(40),
-      expiresAt: daysFromNow(325),
-      clicks: 321,
-    },
-    {
-      id: "15",
-      originalUrl:
-        "https://www.research-paper.example.edu/quantum-computing-advances",
-      shortCode: "quantum",
-      createdAt: daysAgo(90),
-      expiresAt: daysFromNow(275),
-      clicks: 567,
-    },
-  ];
+    const urls: UrlData[] = [];
+    for (const doc of urlsSnapshot.docs) {
+      const data = doc.data();
+
+      let totalClicks = 0;
+      if (
+        data.dailyAccessCounts &&
+        typeof data.dailyAccessCounts === "object"
+      ) {
+        totalClicks = Object.values<number>(data.dailyAccessCounts).reduce(
+          (sum: number, count: number) => sum + count,
+          0,
+        );
+      }
+
+      urls.push({
+        id: doc.id,
+        originalUrl: data.original,
+        shortCode: doc.id,
+        createdAt: data.createdAt
+          ? new Date(data.createdAt).toISOString()
+          : new Date().toISOString(),
+        expiresAt: data.expiresAt
+          ? new Date(data.expiresAt).toISOString()
+          : new Date(Date.now() + 60000 * 60 * 24 * 30).toISOString(),
+        clicks: totalClicks,
+      });
+    }
+
+    return urls;
+  } catch (error) {
+    console.error("Error fetching user URLs from Firestore:", error);
+    return [];
+  }
 }


### PR DESCRIPTION
- Created `DashboardPage` for user URL management with metadata.
- Implemented `UrlDashboard` for displaying and filtering URLs.
- Added `UrlTable` for pagination and actions on URLs.
- Introduced mock data generation in `data.ts` for testing purposes.
- Updated user profile sign-out logic to redirect instead of refreshing.