### PR TITLE
fix: update URL deletion logic to use recursive delete

### DIFF
--- a/src/features/url-dashboard/actions/delete-url.ts
+++ b/src/features/url-dashboard/actions/delete-url.ts
@@ -22,7 +22,8 @@ export const deleteUrl = async (shortCode: string) => {
   }
 
   try {
-    await docRef.delete();
+    await dbAdmin.recursiveDelete(docRef);
+
     return { success: true };
   } catch (error) {
     return {

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,5 +1,5 @@
-import { initializeApp, getApps, cert } from "firebase-admin/app";
-import { DecodedIdToken, getAuth } from "firebase-admin/auth";
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { type DecodedIdToken, getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
 
 if (!getApps().length) {
@@ -31,7 +31,7 @@ export const dbAdmin = getFirestore();
  * @returns The decoded token if valid, null otherwise
  */
 export async function getAuthenticatedUser(
-  authorizationHeader: string | null
+  authorizationHeader: string | null,
 ): Promise<DecodedIdToken | null> {
   if (!authorizationHeader?.startsWith("Bearer ")) {
     return null;


### PR DESCRIPTION
- Replaced `docRef.delete()` with `dbAdmin.recursiveDelete(docRef)` for improved deletion handling.
- Added a missing comma in the `getAuthenticatedUser` function signature for consistency.